### PR TITLE
feat(frontend): catalog → schedule flow; add remove dropdown

### DIFF
--- a/code/frontend/src/App.jsx
+++ b/code/frontend/src/App.jsx
@@ -26,6 +26,8 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register?" element={<Register />} />
+        <Route path="/classSearch-dev" element={<ClassSearch />} />
+
        {user && <Route path="/classSearch" element={<ClassSearch />} />}
        {user && <Route path="/schedule" element={<Schedule />} />}
       </Routes>

--- a/code/frontend/src/Pages/ClassSearch.jsx
+++ b/code/frontend/src/Pages/ClassSearch.jsx
@@ -1,29 +1,135 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
+import { useNavigate, Link } from "react-router-dom";
 
-function ClassSearch() {
 
-     const [courses, setCourses] = useState([]);
-
-     useEffect(() => {
-          fetch("http://localhost:3001/api/courses")
-          .then((res) => res.json())
-          .then((json) => setCourses(json))
-          .catch((err) => console.error("Error fetching courses", err));
-     }, []);
-
-     return (
-          <>
-               <h2>Available Courses</h2>
-               <ul>
-                    {courses.map((course) => (
-                         <li key={course.id}>
-                              {course.code} - {course.title} ({course.instructor})
-                         </li>
-                    ))}
-               </ul>
-
-          </>
-     )
-
+// Map "MWF" -> ["Mon","Wed","Fri"], "TR" -> ["Tue","Thu"]
+function parseDays(short) {
+  const map = { M: "Mon", T: "Tue", W: "Wed", R: "Thu", F: "Fri" };
+  return (short || "")
+    .split("")
+    .map((ch) => map[ch])
+    .filter(Boolean);
 }
-export default ClassSearch;
+
+// Normalize DB row -> UI course shape
+function normalize(row) {
+  return {
+    id: row.id ?? `${row.code}-${row.start_time}-${row.days}`,
+    code: row.code,
+    title: row.title,
+    instructor: row.instructor,
+    start: row.start_time,    // DB uses start_time
+    end: row.end_time,        // DB uses end_time
+    days: Array.isArray(row.days) ? row.days : parseDays(row.days),
+  };
+}
+
+const MOCK = [
+  { id: 1, code: "CPTS101", title: "Intro to Computer Science", instructor: "Dr. Smith",   start: "09:00", end: "10:15", days: ["Mon","Wed","Fri"] },
+  { id: 2, code: "CPTS322", title: "Software Engineering",     instructor: "Dr. Lee",     start: "11:00", end: "12:15", days: ["Tue","Thu"]       },
+  { id: 3, code: "MATH201", title: "Calculus I",                instructor: "Dr. Johnson", start: "14:00", end: "15:15", days: ["Mon","Wed","Fri"] },
+];
+
+export default function ClassSearch() {
+     const navigate = useNavigate();
+  const [courses, setCourses] = useState([]);
+  const [usingMock, setUsingMock] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch("/api/courses") // via Vite proxy (to :3001)
+      .then((res) => {
+        if (!res.ok) throw new Error("bad status");
+        return res.json();
+      })
+      .then((json) => {
+        if (cancelled) return;
+        const list = Array.isArray(json) ? json.map(normalize) : [];
+        setCourses(list.length ? list : MOCK);
+        setUsingMock(!list.length);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCourses(MOCK);
+        setUsingMock(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function addToSchedule(course) {
+    const key = "selectedCourses";
+    const existing = JSON.parse(localStorage.getItem(key) || "[]");
+    const already = existing.some((c) => c.id === course.id);
+    const updated = already ? existing : [...existing, course];
+    localStorage.setItem(key, JSON.stringify(updated));
+    navigate("/schedule");
+  }
+
+  return (
+    <div
+      style={{
+        colorScheme: "light",
+        background: "#f6f8fb",
+        width: "100vw",
+        marginLeft: "calc(50% - 50vw)",
+        marginRight: "calc(50% - 50vw)",
+        minHeight: "100vh",
+        boxSizing: "border-box",
+        padding: 16,
+      }}
+    >
+      <div style={{ maxWidth: 900, margin: "0 auto" }}>
+        <h2 style={{ margin: 0, color: "#0f172a" }}>Available Courses</h2>
+        {usingMock && (
+          <p style={{ fontSize: 12, color: "#6b7280" }}>
+            (Showing mock data — backend DB at <code>/api/courses</code> returned 500 or empty.)
+          </p>
+        )}
+        <ul style={{ listStyle: "none", padding: 0, margin: "12px 0 0 0" }}>
+          {courses.map((c) => (
+            <li
+              key={c.id}
+              style={{
+                border: "1px solid #e5e7eb",
+                borderRadius: 10,
+                padding: "12px 14px",
+                marginBottom: 10,
+                background: "#fff",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+              }}
+            >
+              <div>
+                <div style={{ fontWeight: 800, color: "#0f172a" }}>
+                  {c.code} — {c.title}
+                </div>
+                <div style={{ fontSize: 13, color: "#374151" }}>
+                  {c.instructor} · {c.days.join("/")} · {c.start}–{c.end}
+                </div>
+              </div>
+              <button
+                onClick={() => addToSchedule(c)}
+                style={{
+                  padding: "8px 12px",
+                  borderRadius: 8,
+                  border: "1px solid #cbd5e1",
+                  background: "#f8fafc",
+                  color: "#0f172a",
+                  cursor: "pointer",
+                }}
+              >
+                Add to Schedule
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/code/frontend/src/Pages/Schedule.css
+++ b/code/frontend/src/Pages/Schedule.css
@@ -106,3 +106,36 @@
   border: 1px dashed #e2e8f0;
   border-radius: 10px;
 }
+
+.grid { --slot-h: 100px; }
+.course-cell { position: relative; z-index: 2; }
+.course-block {
+  position: relative;
+  background: #e8f2ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 10px;
+  padding: 8px 10px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  overflow: hidden;
+}
+.course-title { font-weight: 800; font-size: 13px; color: #0f172a; }
+.course-meta  { font-size: 12px; color: #334155; }
+
+/* keep auto-placement simple (row-wise) */
+.grid { grid-auto-flow: row; }
+
+/* pin the time column to the first column no matter what */
+.time-cell { grid-column: 1 !important; }
+
+
+/* remove dropdown styles */
+.remove-panel { margin-top: 12px; }
+.label { font-size: 12px; color: #475569; margin-bottom: 6px; display: block; }
+.select {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #fff;
+}
+.btn.ghost { background: #fff; }

--- a/code/frontend/src/Pages/Schedule.jsx
+++ b/code/frontend/src/Pages/Schedule.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import "./Schedule.css";
 
@@ -6,28 +6,92 @@ const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri"];
 const START_HOUR = 8;   // 8:00 AM
 const END_HOUR = 18;    // 6:00 PM
 
+const DAY_TO_COL = { Mon: 2, Tue: 3, Wed: 4, Thu: 5, Fri: 6 };
+
 function hourLabel(h) {
   const ampm = h >= 12 ? "PM" : "AM";
   const hr12 = ((h + 11) % 12) + 1;
   return `${hr12}:00 ${ampm}`;
 }
 
+function parseTime(t) {
+  if (!t) return { h: START_HOUR, m: 0 };
+  const [hh, mm] = t.split(":").map(Number);
+  return { h: hh, m: mm || 0 };
+}
+
 export default function Schedule() {
   const hours = [];
   for (let h = START_HOUR; h <= END_HOUR; h++) hours.push(h);
 
+  const [selected, setSelected] = useState([]);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem("selectedCourses") || "[]";
+      const list = JSON.parse(raw);
+      if (Array.isArray(list)) setSelected(list);
+    } catch (e) {
+      console.error("Could not read selectedCourses from localStorage", e);
+    }
+  }, []);
+
+  const [removeId, setRemoveId] = useState("");
+
+  function removeSelected() {
+    const next = selected.filter((c) => String(c.id) !== String(removeId));
+    setSelected(next);
+    localStorage.setItem("selectedCourses", JSON.stringify(next));
+    setRemoveId("");
+  }
+
+  function clearSchedule() {
+    localStorage.removeItem("selectedCourses");
+    setSelected([]);
+    setRemoveId("");
+  }
+
   return (
-    <div className="schedule-page">{/* full-bleed + force light colors */}
+    <div className="schedule-page">
       <div className="sched-layout">
         {/* Left sidebar */}
         <aside className="sched-sidebar">
           <h2 className="sidebar-title">Menu</h2>
+
           <Link to="/classSearch" className="btn">Course Catalog</Link>
+
+          {selected.length > 0 && (
+            <div className="remove-panel">
+              <label className="label">Remove a class</label>
+              <select
+                className="select"
+                value={removeId}
+                onChange={(e) => setRemoveId(e.target.value)}
+              >
+                <option value="">— choose —</option>
+                {selected.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.code} — {c.title}
+                  </option>
+                ))}
+              </select>
+
+              <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+                <button className="btn" onClick={removeSelected} disabled={!removeId}>
+                  Remove
+                </button>
+                <button className="btn ghost" onClick={clearSchedule}>
+                  Clear all
+                </button>
+              </div>
+            </div>
+          )}
         </aside>
 
         {/* Main grid */}
         <main className="sched-main">
           <h1 className="sched-title">Weekly Schedule</h1>
+
           <div className="grid">
             {/* top-left corner */}
             <div className="corner" />
@@ -46,6 +110,46 @@ export default function Schedule() {
                 ))}
               </React.Fragment>
             ))}
+
+            {/* COURSE BLOCKS */}
+            {selected.flatMap((c) => {
+              const { h: sh, m: sm } = parseTime(c.start);
+              const { h: eh, m: em } = parseTime(c.end);
+              const startRow = (sh - START_HOUR) + 2; // header row is 1
+              const durationMin = (eh * 60 + em) - (sh * 60 + sm);
+              const rowSpan = Math.max(1, Math.ceil(durationMin / 60));
+              const offsetFrac = Math.max(0, Math.min(59, sm)) / 60; // minute offset
+
+              const days = Array.isArray(c.days) ? c.days : [];
+              return days.map((day) => {
+                const col = DAY_TO_COL[day];
+                if (!col) return null;
+
+                return (
+                  <div
+                    key={`${c.id}-${day}`}
+                    className="course-cell"
+                    style={{
+                      gridColumn: `${col} / ${col + 1}`,
+                      gridRow: `${startRow} / span ${rowSpan}`,
+                    }}
+                  >
+                    <div
+                      className="course-block"
+                      style={{
+                        marginTop: `calc(var(--slot-h) * ${offsetFrac})`,
+                        height: `calc(100% - var(--slot-h) * ${offsetFrac} - 6px)`,
+                      }}
+                    >
+                      <div className="course-title">{c.code}</div>
+                      <div className="course-meta">
+                        {c.title} • {c.instructor} • {c.start}–{c.end}
+                      </div>
+                    </div>
+                  </div>
+                );
+              });
+            })}
           </div>
         </main>
       </div>


### PR DESCRIPTION
- Adds `/classSearch-dev` route with mock fallback (shows courses if `/api/courses` fails/empty)
- “Add to Schedule” stores selections in localStorage and redirects to `/schedule`
- Schedule page reads selections and renders blocks in correct day/time grid
- Sidebar: remove dropdown + Clear all
- Styling: fixes hour column drifting; keeps light, readable styles

2. Frontend:
   - `cd code/frontend && npm run dev` → open `http://localhost:5173`
   - Login → redirected to `/schedule`
   - Go to `/classSearch-dev`, click **Add to Schedule** on 1–2 courses → redirected to `/schedule`
   - Verify blocks show in correct slots
   - Use the sidebar **Remove** dropdown and **Clear all**

### Files touched
- code/frontend/src/App.jsx
- code/frontend/src/Pages/ClassSearch.jsx
- code/frontend/src/Pages/Schedule.jsx
- code/frontend/src/Pages/Schedule.css
- 
### Follow-ups (separate PRs)
- Hook real `/api/courses` to replace mock fallback